### PR TITLE
feat: Add bridgeETH method

### DIFF
--- a/src/actions/bridgeETH.ts
+++ b/src/actions/bridgeETH.ts
@@ -1,0 +1,36 @@
+import {
+  Address,
+  Chain,
+  Transport,
+  Account,
+  WalletClient,
+  SendTransactionParameters,
+} from 'viem'
+import { OpChainL2 } from '@roninjin10/rollup-chains'
+import { bridgeSendTransaction } from './bridgeSendTransaction'
+
+// Currently hardcoded to existing sdk value
+// consider optimizing in future
+const ETH_TRANSFER_L2_GAS = BigInt(200_000)
+
+export async function bridgeETH<
+  TChainL1 extends Chain | undefined = Chain,
+  TChainL2 extends OpChainL2 | undefined = OpChainL2,
+  TAccount extends Account | undefined = Account | undefined,
+  TChainOverride extends Chain | undefined = Chain | undefined,
+>(
+  client: WalletClient<Transport, TChainL1>,
+  { data, value, toChain, account, toAccount, ...restArgs }: { toChain: TChainL2, toAccount: Address | Account, value: bigint } & SendTransactionParameters<TChainL1, TAccount, TChainOverride>,
+): Promise<string> {
+  const to = toAccount ?? account ?? client.account?.address
+  // TODO better typescriptin
+  return bridgeSendTransaction(client as any, {
+    ...restArgs,
+    value,
+    toChain,
+    to: typeof to === 'string' ? to : to.address,
+    data: data ?? '0x0',
+    l2Gas: ETH_TRANSFER_L2_GAS,
+  } as any)
+}
+

--- a/src/actions/bridgeSendTransaction.ts
+++ b/src/actions/bridgeSendTransaction.ts
@@ -1,0 +1,35 @@
+import {
+  Chain,
+  Transport,
+  Account,
+  WalletClient,
+  SendTransactionParameters,
+} from 'viem'
+import { writeContract } from 'viem/actions'
+import { l1CrossDomainMessengerABI } from '@eth-optimism/contracts-ts'
+import { OpChainL2, OpChainL1 } from '@roninjin10/rollup-chains'
+
+export async function bridgeSendTransaction<
+  TChainL1 extends OpChainL1 | undefined = OpChainL1,
+  TChainL2 extends OpChainL2 | undefined = OpChainL2,
+  TAccount extends Account | undefined = Account | undefined,
+  TChainOverride extends Chain | undefined = Chain | undefined,
+>(
+  client: WalletClient<Transport, OpChainL1>,
+  { toChain, to, data, value, l2Gas = BigInt(200_000), ...restArgs }: { toChain: TChainL2, l2Gas?: BigInt } & SendTransactionParameters<TChainL1, TAccount, TChainOverride>,
+
+) {
+  return writeContract(client, {
+    abi: l1CrossDomainMessengerABI,
+    address: toChain?.opContracts.L1CrossDomainMessengerProxy,
+    functionName: 'sendMessage' as any,
+    args: [
+      to,
+      data,
+      l2Gas,
+    ],
+    ...restArgs
+    // TODO better typescriptin
+  } as any)
+}
+

--- a/src/actions/bridgeWriteContract.ts
+++ b/src/actions/bridgeWriteContract.ts
@@ -8,9 +8,8 @@ import {
   EncodeFunctionDataParameters,
   WalletClient,
 } from 'viem'
-import { writeContract } from 'viem/actions'
-import { l1CrossDomainMessengerABI } from '@eth-optimism/contracts-ts'
 import { OpChainL2, OpChainL1 } from '@roninjin10/rollup-chains'
+import { bridgeSendTransaction } from './bridgeSendTransaction'
 
 export async function bridgeWriteContract<
   TAbi extends Abi | readonly unknown[] = Abi,
@@ -21,30 +20,22 @@ export async function bridgeWriteContract<
   TChainOverride extends Chain | undefined = Chain | undefined,
 >(
   client: WalletClient<Transport, TChainL1>,
-  // TODO make this take an l2Chain that is decorated with l2 info such as the l1 contract addreses
-  { toChain, args, abi, address, functionName, ...restArgs }: { toChain: TChainL2 } & WriteContractParameters<TAbi, TFunctionName, TChainL1, TAccount, TChainOverride>,
+  // TODO Document wtf l2Gas is and maybe give it a better name
+  { toChain, args, abi, address, functionName, l2Gas = BigInt(200_000), ...restArgs }: { toChain: TChainL2, l2Gas?: BigInt } & WriteContractParameters<TAbi, TFunctionName, TChainL1, TAccount, TChainOverride>,
 ): Promise<string> {
-  const minGasLimit = 200_000
   const message = encodeFunctionData({
     abi,
     functionName,
     args,
   } as unknown as EncodeFunctionDataParameters<TAbi, TFunctionName>)
-  const l1TxHash = writeContract(client, {
-    abi: l1CrossDomainMessengerABI,
-    // TODO currently hardcoded for OP should get this from the l2 chain object
-    address: toChain?.opContracts.L1CrossDomainMessengerProxy,
-    functionName: 'sendMessage' as any,
-    args: [
-      address,
-      message,
-      minGasLimit,
-    ],
-    ...restArgs
-    // TODO better types
+  // TODO better typescriptin
+  return bridgeSendTransaction(client as any, {
+    ...restArgs,
+    toChain,
+    to: address,
+    data: message,
+    l2Gas,
+    // TODO better typescriptin
   } as any)
-  // compose with getL2Hash method to get l2 hash I think is what we want here
-  // We could consider baking that into this method
-  return l1TxHash
 }
 

--- a/src/actions/bridgeWriteContract.ts
+++ b/src/actions/bridgeWriteContract.ts
@@ -8,18 +8,18 @@ import {
   EncodeFunctionDataParameters,
   WalletClient,
 } from 'viem'
-import { OpChainL2, OpChainL1 } from '@roninjin10/rollup-chains'
+import { OpChainL2 } from '@roninjin10/rollup-chains'
 import { bridgeSendTransaction } from './bridgeSendTransaction'
 
 export async function bridgeWriteContract<
   TAbi extends Abi | readonly unknown[] = Abi,
   TFunctionName extends string = string,
-  TChainL1 extends OpChainL1 | undefined = OpChainL1,
-  TChainL2 extends OpChainL2 | undefined = OpChainL2,
+  TChainL2 extends OpChainL2 = OpChainL2,
+  TChainL1 extends Chain = TChainL2["l1"],
   TAccount extends Account | undefined = Account | undefined,
   TChainOverride extends Chain | undefined = Chain | undefined,
 >(
-  client: WalletClient<Transport, TChainL1>,
+  client: WalletClient<Transport, TChainL2["l1"]>,
   // TODO Document wtf l2Gas is and maybe give it a better name
   { toChain, args, abi, address, functionName, l2Gas = BigInt(200_000), ...restArgs }: { toChain: TChainL2, l2Gas?: BigInt } & WriteContractParameters<TAbi, TFunctionName, TChainL1, TAccount, TChainOverride>,
 ): Promise<string> {

--- a/src/decorators/walletOpStack.ts
+++ b/src/decorators/walletOpStack.ts
@@ -1,6 +1,7 @@
 import { Account, Chain, Transport } from 'viem'
 import { WalletClient } from 'wagmi'
 import { bridgeWriteContract } from '../actions/bridgeWriteContract'
+import { bridgeSendTransaction } from '../actions/bridgeSendTransaction'
 
 /// NOTE We don't currently need account for exisiting actions but keeping in case
 // TODO need to add generics
@@ -8,6 +9,10 @@ export type WalletOpStackActions = {
   bridgeWriteContract: (
     // TODO name these params
     args: Parameters<typeof bridgeWriteContract>[1],
+  ) => Promise<string>
+  bridgeSendTransaction: (
+    // TODO name these params
+    args: Parameters<typeof bridgeSendTransaction>[1],
   ) => Promise<string>
 }
 
@@ -21,5 +26,7 @@ export function publicOpStackActions<
   return {
     // TODO do better than as any
     bridgeWriteContract: (args) => bridgeWriteContract(client as any, args),
+    // TODO do better than as any
+    bridgeSendTransaction: (args) => bridgeSendTransaction(client as any, args)
   }
 }

--- a/src/decorators/walletOpStack.ts
+++ b/src/decorators/walletOpStack.ts
@@ -2,6 +2,7 @@ import { Account, Chain, Transport } from 'viem'
 import { WalletClient } from 'wagmi'
 import { bridgeWriteContract } from '../actions/bridgeWriteContract'
 import { bridgeSendTransaction } from '../actions/bridgeSendTransaction'
+import { bridgeETH } from '../actions/bridgeETH'
 
 /// NOTE We don't currently need account for exisiting actions but keeping in case
 // TODO need to add generics
@@ -13,6 +14,10 @@ export type WalletOpStackActions = {
   bridgeSendTransaction: (
     // TODO name these params
     args: Parameters<typeof bridgeSendTransaction>[1],
+  ) => Promise<string>
+  bridgeETH: (
+    // TODO name these params
+    args: Parameters<typeof bridgeETH>[1],
   ) => Promise<string>
 }
 
@@ -29,6 +34,8 @@ export function publicOpStackActions<
     // TODO do better than as any
     bridgeWriteContract: (args) => bridgeWriteContract(client as any, args),
     // TODO do better than as any
-    bridgeSendTransaction: (args) => bridgeSendTransaction(client as any, args)
+    bridgeSendTransaction: (args) => bridgeSendTransaction(client as any, args),
+    // TODO do better than as any
+    bridgeETH: (args) => bridgeETH(client as any, args)
   }
 }

--- a/src/decorators/walletOpStack.ts
+++ b/src/decorators/walletOpStack.ts
@@ -23,6 +23,8 @@ export function publicOpStackActions<
 >(
   client: WalletClient<TTransport, TChain, TAccount>,
 ): WalletOpStackActions {
+  // TODO none of these decorators are generic
+  // Need to infer args on all of these
   return {
     // TODO do better than as any
     bridgeWriteContract: (args) => bridgeWriteContract(client as any, args),


### PR DESCRIPTION
Stacked on https://github.com/wilsoncusack/op-viem/pull/6

- Adds a method for bridging eth only
- bridgeSendTransaction with a value does the same thing but this method is still nice to have for 2 reasons
  1. It sets the l2Gas for you
  2. It is easier to read what is happening at a glance
  3. it's types are slightly different (requires a value)

This leaves a few more deposit methods needed before all depositMethods are in: 

1. bridgeERC20Token - bridges an erc20 token
2. bridgeERC20TokenBulk - bridges eth and multiple erc20 tokens in a multicall
3. depositExit - exits the rollup via initiating a bulk withdrawal from l1