### PR TITLE
add ToChain generic

### DIFF
--- a/src/actions/wallet/writeUnsafeDepositTransaction.ts
+++ b/src/actions/wallet/writeUnsafeDepositTransaction.ts
@@ -24,7 +24,8 @@ type DepositTransactionParameters = {
 export type WriteUnsafeDepositTransactionParameters<
   TAbi extends Abi | readonly unknown[] = typeof optimismPortalABI,
   TFunctionName extends string = 'depositTransaction',
-  TChain extends Chain | undefined = Chain,
+  TToChain extends OpChainL2 = OpChainL2,
+  TChain extends Chain & { id: TToChain['l1']['id'] } = TToChain["l1"],
   TAccount extends Account | undefined = Account | undefined,
   TChainOverride extends Chain | undefined = Chain | undefined,
 > = Omit<
@@ -37,12 +38,13 @@ export type WriteUnsafeDepositTransactionParameters<
   >,
   'abi' | 'functionName' | 'args' | 'address'
 > & {
-  toChain: OpChainL2
+  toChain: TToChain
   args: DepositTransactionParameters
 }
 
 export async function writeUnsafeDepositTransaction<
-  TChain extends Chain | undefined,
+  TToChain extends OpChainL2,
+  TChain extends Chain & { id: TToChain['l1']['id'] },
   TAccount extends Account | undefined,
   const TAbi extends Abi | readonly unknown[],
   TFunctionName extends string,
@@ -56,6 +58,7 @@ export async function writeUnsafeDepositTransaction<
   }: WriteUnsafeDepositTransactionParameters<
     TAbi,
     TFunctionName,
+    TToChain,
     TChain,
     TAccount,
     TChainOverride

--- a/src/decorators/walletOpStack.ts
+++ b/src/decorators/walletOpStack.ts
@@ -6,11 +6,13 @@ import {
   writeUnsafeDepositTransaction,
 } from '../actions/wallet/writeUnsafeDepositTransaction'
 import { optimismPortalABI } from '@eth-optimism/contracts-ts'
+import { OpChainL2 } from '@roninjin10/rollup-chains'
 
 /// NOTE We don't currently need account for exisiting actions but keeping in case
 // TODO need to add generics
 export type WalletOpStackActions<
-  TChain extends Chain | undefined = Chain | undefined,
+  TToChain extends OpChainL2,
+  TChain extends Chain & { id: TToChain['l1']['id'] },
   TAccount extends Account | undefined = Account | undefined,
 > = {
   bridgeWriteContract: (
@@ -25,6 +27,7 @@ export type WalletOpStackActions<
     args: WriteUnsafeDepositTransactionParameters<
       TAbi,
       TFunctionName,
+      TToChain,
       TChain,
       TAccount,
       TChainOverride
@@ -34,11 +37,12 @@ export type WalletOpStackActions<
 
 export function walletOpStackActions<
   TTransport extends Transport = Transport,
-  TChain extends Chain = Chain,
+  TToChain extends OpChainL2 = OpChainL2,
+  TChain extends Chain & { id: TToChain['l1']['id'] } = TToChain["l1"],
   TAccount extends Account = Account,
 >(
   client: WalletClient<TTransport, TChain, TAccount>,
-): WalletOpStackActions<TChain, TAccount> {
+): WalletOpStackActions<TToChain, TChain, TAccount> {
   return {
     // TODO do better than as any
     bridgeWriteContract: (args) => bridgeWriteContract(client as any, args),


### PR DESCRIPTION
Building on #6, considering dropping the L2/L1 language, but this PR has an issue that ToChain is sometimes an L2 and sometimes an L1 for different wallet actions, so I am not sure the best way to make this generic in the decorator.  